### PR TITLE
Add a manifest to include README.md in source distributions.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Hi, I tried to create a source distribution with `python3 setup.py sdist` but the resulting package was not installable:

```
$ pip install pythonparser-0.0+dev.tar.gz
Processing ./pythonparser-0.0+dev.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/var/folders/84/6bwfrc955bdcvlgnhx2zqwzh0000gn/T/pip-7p1v4b9l-build/setup.py", line 21, in <module>
        long_description=open("README.md").read(),
    FileNotFoundError: [Errno 2] No such file or directory: 'README.md'
```

The fix is really simple: I just tell setup.py to include the readme file.