### PR TITLE
Reverse the order of elif clauses in ast (issue #7)

### DIFF
--- a/pythonparser/parser.py
+++ b/pythonparser/parser.py
@@ -1148,7 +1148,7 @@ class Parser:
         if else_opt:
             stmt.else_loc, stmt.else_colon_loc, stmt.orelse = else_opt
 
-        for elif_ in elifs:
+        for elif_ in reversed(elifs):
             stmt.keyword_loc, stmt.test, stmt.if_colon_loc, stmt.body = elif_
             stmt.loc = stmt.keyword_loc.join(stmt.body[-1].loc)
             if stmt.orelse:

--- a/pythonparser/test/test_parser.py
+++ b/pythonparser/test/test_parser.py
@@ -201,6 +201,7 @@ class ParserTestCase(unittest.TestCase):
     ast_expr_1 = {"ty": "Expr", "value": {"ty": "Num", "n": 1}}
     ast_expr_2 = {"ty": "Expr", "value": {"ty": "Num", "n": 2}}
     ast_expr_3 = {"ty": "Expr", "value": {"ty": "Num", "n": 3}}
+    ast_expr_4 = {"ty": "Expr", "value": {"ty": "Num", "n": 4}}
 
     ast_x = {"ty": "Name", "id": "x", "ctx": None}
     ast_y = {"ty": "Name", "id": "y", "ctx": None}
@@ -1397,18 +1398,21 @@ class ParserTestCase(unittest.TestCase):
 
         self.assertParsesSuite(
             [{"ty": "If", "test": self.ast_x, "body": [self.ast_expr_1], "orelse": [
-                {"ty": "If", "test": self.ast_y, "body": [self.ast_expr_2],
-                 "orelse": [self.ast_expr_3]}
-            ]}],
-            "if x:·  1·elif y:·  2·else:·  3",
+               {"ty": "If", "test": self.ast_y, "body": [self.ast_expr_2], "orelse": [
+                 {"ty": "If", "test": self.ast_z, "body": [self.ast_expr_3],
+                  "orelse": [self.ast_expr_4]}
+            ]}]}],
+            "if x:·  1·elif y:·  2·elif z:·  3·else:·  4",
             "^^ 0.keyword_loc"
             "    ^ 0.if_colon_loc"
             "          ~~~~ 0.orelse.0.keyword_loc"
             "                ^ 0.orelse.0.if_colon_loc"
-            "                      ~~~~ 0.orelse.0.else_loc"
-            "                          ^ 0.orelse.0.else_colon_loc"
-            "          ~~~~~~~~~~~~~~~~~~~~~ 0.orelse.0.loc"
-            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 0.loc")
+            "                      ~~~~ 0.orelse.0.orelse.0.keyword_loc"
+            "                            ^ 0.orelse.0.orelse.0.if_colon_loc"
+            "                                  ~~~~ 0.orelse.0.orelse.0.else_loc"
+            "                                      ^ 0.orelse.0.orelse.0.else_colon_loc"
+            "          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 0.orelse.0.loc"
+            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 0.loc")
 
     def test_while(self):
         self.assertParsesSuite(

--- a/pythonparser/test/test_parser.py
+++ b/pythonparser/test/test_parser.py
@@ -1398,21 +1398,28 @@ class ParserTestCase(unittest.TestCase):
 
         self.assertParsesSuite(
             [{"ty": "If", "test": self.ast_x, "body": [self.ast_expr_1], "orelse": [
-               {"ty": "If", "test": self.ast_y, "body": [self.ast_expr_2], "orelse": [
-                 {"ty": "If", "test": self.ast_z, "body": [self.ast_expr_3],
-                  "orelse": [self.ast_expr_4]}
-            ]}]}],
-            "if x:·  1·elif y:·  2·elif z:·  3·else:·  4",
+                {"ty": "If", "test": self.ast_y, "body": [self.ast_expr_2],
+                 "orelse": [self.ast_expr_3]}
+            ]}],
+            "if x:·  1·elif y:·  2·else:·  3",
             "^^ 0.keyword_loc"
             "    ^ 0.if_colon_loc"
             "          ~~~~ 0.orelse.0.keyword_loc"
             "                ^ 0.orelse.0.if_colon_loc"
-            "                      ~~~~ 0.orelse.0.orelse.0.keyword_loc"
-            "                            ^ 0.orelse.0.orelse.0.if_colon_loc"
-            "                                  ~~~~ 0.orelse.0.orelse.0.else_loc"
-            "                                      ^ 0.orelse.0.orelse.0.else_colon_loc"
-            "          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 0.orelse.0.loc"
-            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 0.loc")
+            "                      ~~~~ 0.orelse.0.else_loc"
+            "                          ^ 0.orelse.0.else_colon_loc"
+            "          ~~~~~~~~~~~~~~~~~~~~~ 0.orelse.0.loc"
+            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 0.loc")
+
+        # Ensure elif nodes are in the correct order.
+        # See: https://github.com/m-labs/pythonparser/issues/7
+        self.assertParsesSuite(
+            [{"ty": "If", "test": self.ast_x, "body": [self.ast_expr_1], "orelse": [
+               {"ty": "If", "test": self.ast_y, "body": [self.ast_expr_2], "orelse": [
+                 {"ty": "If", "test": self.ast_z, "body": [self.ast_expr_3],
+                  "orelse": [self.ast_expr_4]}
+            ]}]}],
+            "if x:·  1·elif y:·  2·elif z:·  3·else:·  4")
 
     def test_while(self):
         self.assertParsesSuite(


### PR DESCRIPTION
This addressed https://github.com/m-labs/pythonparser/issues/7 for me, although I'm not sure it's the best way. I also wasn't sure how to test this, but I'm happy to add one if I can get a little guidance about what's going on here: https://github.com/m-labs/pythonparser/blob/master/pythonparser/test/test_parser.py#L1380