### PR TITLE
Accept to parse sources not ending with '\n'

### DIFF
--- a/pythonparser/__init__.py
+++ b/pythonparser/__init__.py
@@ -54,6 +54,9 @@ def parse(source, filename="<unknown>", mode="exec",
     :raise: :class:`diagnostic.Error`
         if the source code is not well-formed
     """
+    if not source.endswith('\n'):
+        source += '\n'
+
     ast, comments = parse_buffer(pythonparser.source.Buffer(source, filename),
                                  mode, flags, version, engine)
     return ast


### PR DESCRIPTION
Allows the source to be parsed to not end in a endline (``\n``), as the stdlib ``ast`` module does.

The goal is to have a ``pythonparser`` as near as possible to a drop-in replacement of ``ast``.

This and other compatibility PRs will allows less changes on https://github.com/google/grumpy/pull/216, for example.