### PR TITLE
Implementation of .lineno as a property of .loc

### DIFF
--- a/pythonparser/ast.py
+++ b/pythonparser/ast.py
@@ -57,6 +57,15 @@ class commonloc(object):
                            self._reprfields()))
         return "%s(%s)" % (self.__class__.__name__, fields)
 
+    # Compat with stdlib
+    @property
+    def lineno(self):
+        return self.loc
+    @lineno.setter
+    def lineno(self, value):
+        self.loc = value
+
+
 class keywordloc(commonloc):
     """
     A mixin common for all keyword statements, e.g. ``pass`` and ``yield expr``.

--- a/pythonparser/ast.py
+++ b/pythonparser/ast.py
@@ -60,10 +60,7 @@ class commonloc(object):
     # Compat with stdlib
     @property
     def lineno(self):
-        return self.loc
-    @lineno.setter
-    def lineno(self, value):
-        self.loc = value
+        return self.loc.line()
 
 
 class keywordloc(commonloc):


### PR DESCRIPTION
Implementation of ``ast.AST.lineno`` as a property of ``commonloc``.

The stdlib ``ast`` module nodes expose the line on ``ast.AST.lineno``, while ``pythonparser.ast.commonloc.loc`` seems to cast to the same information. Maybe I had not understood the way pythonparser do this things, but the getter/setter can be updated to do the right thing if needed.

The goal is to have a pythonparser as near as possible to a drop-in replacement of ast.

This and other compatibility PRs will allows less changes on google/grumpy#216, for example.