### PR TITLE
Allow positional __init__ attributes on the AST classes

### DIFF
--- a/pythonparser/ast.py
+++ b/pythonparser/ast.py
@@ -85,7 +85,10 @@ class AST(object):
     """
     _fields = ()
 
-    def __init__(self, **fields):
+    def __init__(self, *args, **fields):
+        if args:
+            fields.update(dict(zip(self._fields, args)))
+
         for field in fields:
             setattr(self, field, fields[field])
 


### PR DESCRIPTION
On pythonparser the AST nodes are needed to pass the attribute names explicitly on the instantiation (e.g. ``ast.Expr(value=ast.Yield(value=node.elt)``), but stdlib ast allows this to be positional (e.g ``ast.Expr(ast.Yield(node.elt)``).

This PR raises the compatibility with stdlib ast. The goal is to have a pythonparser as near as possible to a drop-in replacement of ast.

This and other compatibility PRs will allows less changes on google/grumpy#216, for example.