### PR TITLE
Detect source encoding to properly interpret string literals

### DIFF
--- a/pythonparser/lexer.py
+++ b/pythonparser/lexer.py
@@ -421,14 +421,16 @@ class Lexer:
                           "strend"))
 
     def _replace_escape(self, range, mode, value):
+        is_raw     = ("r" in mode)
         is_unicode = "u" in mode or ("b" not in mode and self.unicode_literals)
+
         if not is_unicode:
             value = value.encode(self.source_buffer.encoding)
-            if "r" in mode:
+            if is_raw:
                 return value
             return self._replace_escape_bytes(value)
 
-        if "r" in mode:
+        if is_raw:
             return value
 
         return self._replace_escape_unicode(range, value)
@@ -449,24 +451,24 @@ class Lexer:
 
             # Process the escape
             if match.group(1) is not None: # single-char
-                c = match.group(1)
-                if c == "\n":
+                chr = match.group(1)
+                if chr == "\n":
                     pass
-                elif c == "\\" or c == "'" or c == "\"":
-                    chunks.append(c)
-                elif c == "a":
+                elif chr == "\\" or chr == "'" or chr == "\"":
+                    chunks.append(chr)
+                elif chr == "a":
                     chunks.append("\a")
-                elif c == "b":
+                elif chr == "b":
                     chunks.append("\b")
-                elif c == "f":
+                elif chr == "f":
                     chunks.append("\f")
-                elif c == "n":
+                elif chr == "n":
                     chunks.append("\n")
-                elif c == "r":
+                elif chr == "r":
                     chunks.append("\r")
-                elif c == "t":
+                elif chr == "t":
                     chunks.append("\t")
-                elif c == "v":
+                elif chr == "v":
                     chunks.append("\v")
             elif match.group(2) is not None: # oct
                 chunks.append(unichr(int(match.group(2), 8)))
@@ -513,24 +515,24 @@ class Lexer:
 
             # Process the escape
             if match.group(1) is not None: # single-char
-                c = match.group(1)
-                if c == b"\n":
+                chr = match.group(1)
+                if chr == b"\n":
                     pass
-                elif c == b"\\" or c == b"'" or c == b"\"":
-                    chunks.append(c)
-                elif c == b"a":
+                elif chr == b"\\" or chr == b"'" or chr == b"\"":
+                    chunks.append(chr)
+                elif chr == b"a":
                     chunks.append(b"\a")
-                elif c == b"b":
+                elif chr == b"b":
                     chunks.append(b"\b")
-                elif c == b"f":
+                elif chr == b"f":
                     chunks.append(b"\f")
-                elif c == b"n":
+                elif chr == b"n":
                     chunks.append(b"\n")
-                elif c == b"r":
+                elif chr == b"r":
                     chunks.append(b"\r")
-                elif c == b"t":
+                elif chr == b"t":
                     chunks.append(b"\t")
-                elif c == b"v":
+                elif chr == b"v":
                     chunks.append(b"\v")
             elif match.group(2) is not None: # oct
                 chunks.append(byte(int(match.group(2), 8)))

--- a/pythonparser/parser.py
+++ b/pythonparser/parser.py
@@ -520,6 +520,8 @@ class Parser:
     def add_flags(self, flags):
         if "print_function" in flags:
             self.lexer.print_function = True
+        if "unicode_literals" in flags:
+            self.lexer.unicode_literals = True
 
     # Grammar
     @action(Expect(Alt(Newline(),
@@ -1522,7 +1524,10 @@ class Parser:
 
     @action(Plus(atom_4))
     def atom_5(self, strings):
-        return ast.Str(s="".join([x.s for x in strings]),
+        joint = ""
+        if all(isinstance(x.s, bytes) for x in strings):
+            joint = b""
+        return ast.Str(s=joint.join([x.s for x in strings]),
                        begin_loc=strings[0].begin_loc, end_loc=strings[-1].end_loc,
                        loc=strings[0].loc.join(strings[-1].loc))
 

--- a/pythonparser/source.py
+++ b/pythonparser/source.py
@@ -70,16 +70,26 @@ class Buffer:
                 return self._line_begins
             self._line_begins.append(index)
 
-    _encoding_re = re.compile(b"^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+    _encoding_re = re.compile("^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+    _encoding_bytes_re = re.compile(_encoding_re.pattern.encode())
 
     def _extract_encoding(self, source):
-        match = self._encoding_re.match(source)
+        if isinstance(source, bytes):
+            re = self._encoding_bytes_re
+            nl = b"\n"
+        else:
+            re = self._encoding_re
+            nl = "\n"
+        match = re.match(source)
         if not match:
-            index = source.find(b"\n")
+            index = source.find(nl)
             if index != -1:
-                match = self._encoding_re.match(source[index + 1:])
+                match = re.match(source[index + 1:])
         if match:
-            return match.group(1)
+            encoding = match.group(1)
+            if isinstance(encoding, bytes):
+                return encoding.decode("ascii")
+            return encoding
         return "ascii"
 
 

--- a/pythonparser/test/test_lexer.py
+++ b/pythonparser/test/test_lexer.py
@@ -1,8 +1,12 @@
 # coding:utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+from . import test_utils
 from .. import source, lexer, diagnostic
 import unittest
+
+BytesOnly = test_utils.BytesOnly
+UnicodeOnly = test_utils.UnicodeOnly
 
 class LexerTestCase(unittest.TestCase):
 
@@ -152,61 +156,66 @@ class LexerTestCase(unittest.TestCase):
                          "int", 123)
 
     def test_string_literal(self):
-        self.assertLexes("''",
-                         "strbegin", "",
-                         "strdata",  "",
-                         "strend",   None)
-        self.assertLexes("''''''",
-                         "strbegin", "",
-                         "strdata",  "",
-                         "strend",   None)
-        self.assertLexes("\"\"",
-                         "strbegin", "",
-                         "strdata",  "",
-                         "strend",   None)
-        self.assertLexes("\"\"\"\"\"\"",
-                         "strbegin", "",
-                         "strdata",  "",
-                         "strend",   None)
+        for version in self.VERSIONS:
+            if version < (3,):
+                str_type = BytesOnly
+            else:
+                str_type = UnicodeOnly
+            self.assertLexesVersions("''", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type(""),
+                                     "strend",   None)
+            self.assertLexesVersions("''''''", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type(""),
+                                     "strend",   None)
+            self.assertLexesVersions("\"\"", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type(""),
+                                     "strend",   None)
+            self.assertLexesVersions("\"\"\"\"\"\"", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type(""),
+                                     "strend",   None)
 
-        self.assertLexes("'x'",
-                         "strbegin", "",
-                         "strdata",  "x",
-                         "strend",   None)
+            self.assertLexesVersions("'x'", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type("x"),
+                                     "strend",   None)
 
-        self.assertLexes("'''\n'''",
-                         "strbegin", "",
-                         "strdata",  "\n",
-                         "strend",   None)
+            self.assertLexesVersions("'''\n'''", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type("\n"),
+                                     "strend",   None)
 
-        self.assertLexes("'''\n'''",
-                         "strbegin", "",
-                         "strdata",  "\n",
-                         "strend",   None)
+            self.assertLexesVersions("'''\n'''", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type("\n"),
+                                     "strend",   None)
 
-        self.assertLexes(r"'\0 \10 \010'",
-                         "strbegin", "",
-                         "strdata",  "\x00 \x08 \x08",
-                         "strend",   None)
+            self.assertLexesVersions(r"'\0 \10 \010'", [version],
+                                     "strbegin", "",
+                                     "strdata",  str_type("\x00 \x08 \x08"),
+                                     "strend",   None)
 
         self.assertLexesVersions(r"b'\xc3\xa7'", [(2,7), (3,0), (3,1)],
                                  "strbegin", "b",
-                                 "strdata",  b"\xc3\xa7",
+                                 "strdata",  BytesOnly(b"\xc3\xa7"),
                                  "strend",   None)
 
         self.assertLexesVersions(b"# coding: koi8-r\nb'\xc3\xa7'", [(2,7), (3,0), (3,1)],
                                  "strbegin", "b",
-                                 "strdata",  b"\xc3\xa7",
+                                 "strdata",  BytesOnly(b"\xc3\xa7"),
                                  "strend",   None)
 
         self.assertLexesVersions(b"# coding: koi8-r\n'\xc3\xa7'", [(3,0), (3,1)],
                                  "strbegin", "",
-                                 "strdata",  "\u0446\u2556",
+                                 "strdata",  UnicodeOnly("\u0446\u2556"),
                                  "strend",   None)
 
         self.assertLexesVersions(b"# coding: koi8-r\nu'\xc3\xa7'", [(2,7)],
                                  "strbegin", "u",
-                                 "strdata",  "\u0446\u2556",
+                                 "strdata",  UnicodeOnly("\u0446\u2556"),
                                  "strend",   None)
 
         self.assertDiagnoses(
@@ -231,12 +240,13 @@ class LexerTestCase(unittest.TestCase):
                 (r"\a", "\a"), (r"\b", "\b"), (r"\f", "\f"), (r"\n", "\n"),
                 (r"\r", "\r"), (r"\t", "\t"), (r"\v", "\v"),
                 (r"\x53", "S"), (r"\123", "S")]:
-            for mode in [ "", "u", "b" ]:
-                self.assertLexesEscape(mode, chr, val)
-            for mode in [ "r", "br" ]:
-                self.assertLexesEscape(mode, chr, chr)
+            self.assertLexesEscape("b", chr, BytesOnly(val))
+            self.assertLexesEscape("u", chr, UnicodeOnly(val))
+            self.assertLexesEscape("", chr, UnicodeOnly(val))
+            self.assertLexesEscape("r", chr, UnicodeOnly(chr))
+            self.assertLexesEscape("br", chr, BytesOnly(chr))
 
-        self.assertLexesEscape("r", "\\\"", "\\\"")
+        self.assertLexesEscape("r", "\\\"", UnicodeOnly("\\\""))
 
     def test_escape_unicode(self):
         self.assertLexesEscape("u", "\\u044b", "ы")

--- a/pythonparser/test/test_lexer.py
+++ b/pythonparser/test/test_lexer.py
@@ -189,6 +189,26 @@ class LexerTestCase(unittest.TestCase):
                          "strdata",  "\x00 \x08 \x08",
                          "strend",   None)
 
+        self.assertLexesVersions(r"b'\xc3\xa7'", [(2,7), (3,0), (3,1)],
+                                 "strbegin", "b",
+                                 "strdata",  b"\xc3\xa7",
+                                 "strend",   None)
+
+        self.assertLexesVersions(b"# coding: koi8-r\nb'\xc3\xa7'", [(2,7), (3,0), (3,1)],
+                                 "strbegin", "b",
+                                 "strdata",  b"\xc3\xa7",
+                                 "strend",   None)
+
+        self.assertLexesVersions(b"# coding: koi8-r\n'\xc3\xa7'", [(3,0), (3,1)],
+                                 "strbegin", "",
+                                 "strdata",  "\u0446\u2556",
+                                 "strend",   None)
+
+        self.assertLexesVersions(b"# coding: koi8-r\nu'\xc3\xa7'", [(2,7)],
+                                 "strbegin", "u",
+                                 "strdata",  "\u0446\u2556",
+                                 "strend",   None)
+
         self.assertDiagnoses(
                          "'",
                          [("fatal", "unterminated string", (0, 1))])

--- a/pythonparser/test/test_parser.py
+++ b/pythonparser/test/test_parser.py
@@ -259,7 +259,10 @@ class ParserTestCase(unittest.TestCase):
             "b'foo'",
             "~~~~~~ loc"
             "~~ begin_loc"
-            "     ^ end_loc")
+            "     ^ end_loc",
+            # Python 3.4 for some reason produces a Bytes node where all other
+            # known versions produce Str.
+            validate_if=lambda: sys.version_info != (3, 4))
 
         self.assertParsesExpr(
             {"ty": "Str", "s": BytesOnly(b"foo")},

--- a/pythonparser/test/test_parser.py
+++ b/pythonparser/test/test_parser.py
@@ -262,7 +262,7 @@ class ParserTestCase(unittest.TestCase):
             "     ^ end_loc",
             # Python 3.4 for some reason produces a Bytes node where all other
             # known versions produce Str.
-            validate_if=lambda: sys.version_info != (3, 4))
+            validate_if=lambda: sys.version_info[:2] != (3, 4))
 
         self.assertParsesExpr(
             {"ty": "Str", "s": BytesOnly(b"foo")},

--- a/pythonparser/test/test_source.py
+++ b/pythonparser/test/test_source.py
@@ -28,6 +28,13 @@ class BufferTestCase(unittest.TestCase):
         self.assertEqual((2, 0),
                          source.Buffer("\n").decompose_position(1))
 
+    def test_encoding(self):
+        self.assertEqual("ascii", source.Buffer("\n").encoding)
+        self.assertEqual("ascii", source.Buffer("coding: wut").encoding)
+        self.assertEqual("ascii", source.Buffer("\n\n# coding: wut").encoding)
+        self.assertEqual("utf-8", source.Buffer("# coding=utf-8").encoding)
+        self.assertEqual("iso-8859-1", source.Buffer("\n# -*- coding: iso-8859-1 -*-").encoding)
+
 
 class RangeTestCase(unittest.TestCase):
 

--- a/pythonparser/test/test_utils.py
+++ b/pythonparser/test/test_utils.py
@@ -1,0 +1,24 @@
+# coding:utf-8
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+unicode = type("")
+
+class BytesOnly(bytes):
+    def __new__(cls, s):
+        if isinstance(s, unicode):
+            s = s.encode()
+        return bytes.__new__(BytesOnly, s)
+
+    def __eq__(self, o):
+        return isinstance(o, bytes) and bytes.__eq__(self, o)
+
+    def __ne__(self, o):
+        return not self == o
+
+class UnicodeOnly(unicode):
+    def __eq__(self, o):
+        return isinstance(o, unicode) and unicode.__eq__(self, o)
+
+    def __ne__(self, o):
+        return not self == o


### PR DESCRIPTION
This addresses https://github.com/m-labs/pythonparser/issues/6

Buffers now always hold unicode source, whereas before they could hold bytes if that's what were passed in to the constructor. This is possible because we determine the encoding and then use that to decode() the bytes. The side effect is that `Buffer.__init__` could raise UnicodeDecodeError if the input is badly encoded.

The Buffer encoding is then used by the lexer to produce a strdata token of the correct type for string literals. For unicode literals, escaping happens much as before via _replace_escape(). For bytes, there's a different code path that calls encode() using the Buffer's encoding followed by a special escaping function that ensures the value's not accidentally promoted to unicode.

The parser behavior for multi-string literals (e.g. `"foo" "bar"`) also had to change. When any of the literals are unicode, the result is unicode. When all the literals are bytes the resulting value is also bytes.

This PR also implements the unicode_literals future feature in a similar fashion to print_function. The one shortcoming of that approach is that it does not affect all string literals in the file, only the ones after the current lexer position. I think a proper implementation would require doing a lexer pass on the input to activate future flags before parsing. I didn't want to add any more complexity to this PR since it's already getting a bit big and this seems good enough for now.