### PR TITLE
Travis CI: flake8 tests to find Python syntax errors & undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
+before_script:
+  - pip install flake8
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - python setup.py test

--- a/pythonparser/source.py
+++ b/pythonparser/source.py
@@ -256,7 +256,7 @@ class RewriterConflict(Exception):
 
     def __init__(self, first, second):
         self.first, self.second = first, second
-        exception.__init__(self, "Ranges %s and %s overlap" % (repr(first), repr(second)))
+        Exception.__init__(self, "Ranges %s and %s overlap" % (repr(first), repr(second)))
 
 class Rewriter:
     """

--- a/pythonparser/test/test_utils.py
+++ b/pythonparser/test/test_utils.py
@@ -27,7 +27,7 @@ class UnicodeOnly(unicode):
 try:
     class LongOnly(long):  # Python 2
         def __eq__(self, o):
-            return isinstance(o, long) and long.__cmp__(self, o) == 0
+            return isinstance(o, long) and long.__cmp__(self, o) == 0  # noqa
 
         def __ne__(self, o):
             return not self == o

--- a/pythonparser/test/test_utils.py
+++ b/pythonparser/test/test_utils.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-import sys
+
 
 unicode = type("")
 
@@ -24,12 +24,12 @@ class UnicodeOnly(unicode):
     def __ne__(self, o):
         return not self == o
 
-if sys.version_info >= (3,):
-    LongOnly = int
-else:
-    class LongOnly(long):
+try:
+    class LongOnly(long):  # Python 2
         def __eq__(self, o):
             return isinstance(o, long) and long.__cmp__(self, o) == 0
 
-    def __ne__(self, o):
-        return not self == o
+        def __ne__(self, o):
+            return not self == o
+except NameError:          # Python 3
+    LongOnly = int


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

---

Undefined name: __exception__ --> __Exception__

__exception__ (lowercase 'e') is an undefined name in this context while __Exception__ (uppercase 'e') is the superclass.

flake8 testing of https://github.com/m-labs/pythonparser on Python 2.7.14

$ flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
```
./pythonparser/source.py:259:9: F821 undefined name 'exception'
        exception.__init__(self, "Ranges %s and %s overlap" % (repr(first), repr(second)))
        ^
1     F821 undefined name 'exception'
1
```

---

Fix indentation error in `LongOnly.__ne__()`
* Also follow Python porting best practice [__use feature detection instead of version detection__](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

