### PR TITLE
Accepts empty print_stmt with destination fp

### DIFF
--- a/pythonparser/parser.py
+++ b/pythonparser/parser.py
@@ -905,12 +905,17 @@ class Parser:
         return ast.Print(dest=dest, values=values, nl=nl,
                          dest_loc=dest_loc, loc=loc)
 
+    @action(Seq(Loc(">>"), Rule("test")))
+    def print_stmt_3(self, dest_loc, dest):
+        return ast.Print(dest=dest, values=[], nl=True,
+                         dest_loc=dest_loc, loc=dest_loc)
+
     @action(Eps())
-    def print_stmt_3(self, eps):
+    def print_stmt_4(self, eps):
         return ast.Print(dest=None, values=[], nl=True,
                          dest_loc=None, loc=None)
 
-    @action(Seq(Loc("print"), Alt(print_stmt_1, print_stmt_2, print_stmt_3)))
+    @action(Seq(Loc("print"), Alt(print_stmt_1, print_stmt_2, print_stmt_3, print_stmt_4)))
     def print_stmt(self, print_loc, stmt):
         """
         (2.6-2.7)

--- a/pythonparser/test/test_parser.py
+++ b/pythonparser/test/test_parser.py
@@ -1154,6 +1154,14 @@ class ParserTestCase(unittest.TestCase):
             "~~~~~~~~~~~~~ 0.loc",
             only_if=lambda ver: ver < (3, 0))
 
+        self.assertParsesSuite(
+            [{"ty": "Print", "dest": self.ast_2, "values": [], "nl": True}],
+            "print >>2",
+            "~~~~~ 0.keyword_loc"
+            "      ~~ 0.dest_loc"
+            "~~~~~~~~ 0.loc",
+            only_if=lambda ver: ver < (3, 0))
+
     def test_del(self):
         self.assertParsesSuite(
             [{"ty": "Delete", "targets": [self.ast_x]}],


### PR DESCRIPTION
As in `print >> self.stdout` with no value