### PR TITLE
parser.Parser explicitly inheriting from object

### DIFF
--- a/pythonparser/parser.py
+++ b/pythonparser/parser.py
@@ -349,7 +349,7 @@ def BeginEnd(begin_tok, inner_rule, end_tok, empty=None, loc=None):
         return node
     return rule
 
-class Parser:
+class Parser(object):
 
     # Generic LL parsing methods
     def __init__(self, lexer, version, diagnostic_engine):


### PR DESCRIPTION
This allows Python 2.7 code to inherit the parser without monkeypatches

See: https://github.com/grumpyhome/grumpy/pull/117#issue-225903144